### PR TITLE
Changing FileShare mode on WriteOnly Mode to Read.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See the arguments used in the FileStream constructor depending of the choosed mo
 #### WriteOnly
 * **FileMode** - Append
 * **FileAccess** - Write
-* **FileShare** - ReadWrite
+* **FileShare** - Read
 * **FileOptions** - SequentialScan
 
 #### ReadAndWrite
@@ -51,7 +51,7 @@ See the arguments used in the FileStream constructor depending of the choosed mo
 
 ### Default Values
 
-#### DEFAULT\_BUFFER\_SIZE = 512 Kbytes
+#### DEFAULT\_BUFFER\_SIZE = 4096 bytes
 The buffer size passed to the FileStream constructor.
 
 

--- a/src/JsonStream/JsonStream.cs
+++ b/src/JsonStream/JsonStream.cs
@@ -116,7 +116,7 @@ namespace StoneCo.Utils.IO
             {
                 fileMode = FileMode.Append;
                 fileAccess = FileAccess.Write;
-                fileShare = FileShare.ReadWrite;
+                fileShare = FileShare.Read;
                 fileOptions = FileOptions.SequentialScan;
             }
             else if(Mode == Modes.ReadOnly)

--- a/src/JsonStream/JsonStream.csproj
+++ b/src/JsonStream/JsonStream.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>json, stream, csharp, dotnet, dotnetstandard, jsonstream, filestream, jsonfile</PackageTags>
     <PackageReleaseNotes>Changing DEFAULT_BUFFER_SIZE to 4096 bytes and using ReaderWriterLockSlim semaphore.</PackageReleaseNotes>
-    <Version>1.0.16</Version>
+    <Version>1.0.17</Version>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 


### PR DESCRIPTION
It is needed to avoid multiple threads to write in the stream at the same time.